### PR TITLE
draft: Update runtime to 23.08

### DIFF
--- a/com.github.treagod.spectator.json
+++ b/com.github.treagod.spectator.json
@@ -1,10 +1,10 @@
 {
     "app-id": "com.github.treagod.spectator",
     "base": "io.elementary.BaseApp",
-    "base-version": "juno-22.08",
-    "runtime": "org.gnome.Platform",
-    "sdk": "org.gnome.Sdk",
-    "runtime-version": "44",
+    "base-version": "juno-23.08",
+    "runtime": "org.freedesktop.Platform",
+    "sdk": "org.freedesktop.Sdk",
+    "runtime-version": "23.08",
     "command": "com.github.treagod.spectator",
     "finish-args": [
         "--share=ipc",


### PR DESCRIPTION
GNOME runtime version 44 has reached EOL.